### PR TITLE
Updated documentation...

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,7 +62,10 @@ return [
             'exceptions'    => true,
             'async'         => false,
             'rate_limit'    => 1,
-            'handlers'      => []
+            'handlers'      => [
+                //Add/Register Your Handlers & Commands Here
+                 \Some\Path\To\Your\Commands\StartCommand::class
+            ]
         ],
         'bot2' => [
             'token'         => env('TELEGRAM_BOT2_TOKEN', '<telegram api token>')

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,1 +1,87 @@
-## Guide
+## Examples / Guide
+
+### Further Laravel Setup Help
+---
+To begin receiving updates from the telegram server, after setting your *webhook* by using the `php artisan telebot:webhook -S` command - (which must be done after setting the details in either your `TeleBot.php` config file or your `.env` file.) 
+
+You need to add a route in your `routes/web.php` file, that matches the webhook_url you set in your `.env` &/or config file.
+
+Here is an example:
+```
+//routes/web.php
+
+Route::post('/webhook', [WebhookController::class, 'webhook']);
+...
+```
+
+Next you need to create a Controller so that when telegram "posts" data to your `/webhook` url it is handled by the `WebhookController::class` in this instance.
+
+### Creating a controller using laravels built-in artisan command. 
+
+From the terminal, type
+`php artisan make:controller WebhookController`, where "`WebhookController`" is the name you want to give to your Controller.
+
+```
+<?php
+//app/Http/Controllers/WebhookController.php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use WeStacks\TeleBot\Laravel\TeleBot as Bot;
+
+class WebhookController extends Controller
+{
+        public function webhook()
+        {
+                $update = TeleBot::bot('bot')->handleUpdate();
+        }
+
+}
+```
+
+### Adding the example StartCommand
+
+Add the following code wherever you want to store your commands, just be sure to correctly set the namespace (Capitalise first letters of all directories in namespace!)
+
+This example stores commands inside the `app` directory, creating a new `Telegram` directory and a `Commands` directory inside that to store the commands.
+
+```
+<?php
+// app/Telegram/Commands/StartCommand.php
+
+namespace App\Telegram\Commands;
+
+use WeStacks\TeleBot\Handlers\CommandHandler;
+
+class StartCommand extends CommandHandler
+{
+    /**
+     * Command aliasses that trigger this bot command
+     */
+    protected static $aliases = [ '/start', '/s' ];
+
+    /**
+     * Command description for Telegram API
+     */
+    protected static $description = 'Send "/start" or "/s" to get "Hello, World!"';
+
+    /**
+     * Handle bot command
+     */
+    public function handle()
+    {
+        /**
+         *  If you fire bot method on UpdateHandler instance, the default values for parameters: 'chat_id', 'user_id',
+         *  'message_id', 'callback_query_id', 'inline_message_id', 'inline_query_id', 'shipping_query_id',
+         *  'pre_checkout_query_id' - will be taken from incoming Update object. You still may override them pathing them
+         *  to array of parameters:
+         */
+
+        $this->sendMessage([
+            'text' => 'Hello, World!'
+        ]);
+    }
+}
+
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,6 +16,8 @@ composer require westacks/telebot
 
 If you are using Laravel, the library will self-register its ServiceProvider and Facade using Laravel's auto-discovery. Only Laravel version 5.5+ supported by the library.
 
+Tested working with 6.x.
+
 ### Publish Configuration File
 
 Open your terminal window and fire the following command to publish config file to your config directory:
@@ -24,3 +26,14 @@ Open your terminal window and fire the following command to publish config file 
 php artisan vendor:publish --provider="WeStacks\TeleBot\Laravel\TeleBotServiceProvider"
 ```
 Now you can find your bots config on `config/telebot.php` file.
+
+### Optional \ Additional Configuration Options
+
+You may add the following to your .env file if you would prefer to edit the settings later from there.
+```
+ TELEGRAM_BOT_TOKEN=
+ TELEGRAM_BOT_WEBHOOK_URL=
+ TELEGRAM_BOT_CERT_PATH=
+ ```
+Check the examples in the `telebot.php` config file to understand how to add multiple tokens.
+


### PR DESCRIPTION
added examples to the empty Guide docs page and explained parts in more detail that users may have otherwise found confusing.

Guide page still needs adding to the main docs sidebar, I think ideally placed beneath the "`configuration`" navbar option is best.

Should be
```
...
Installation
Configuration
Examples / Guides
Objects
Methods
...
```