### PR TITLE
1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,3 +47,7 @@ All notable changes to `telebot` will be documented in this file
 - `WeStacks\TeleBot\Laravel\TelegramMessage` renamed to `WeStacks\TeleBot\Laravel\TelegramNotification`.
 - Telegram notification now can be sent only using `WeStacks\TeleBot\Laravel\TelegramNotification` object. Old array system is dropped
 - When sending notification using `WeStacks\TeleBot\Laravel\TelegramNotification`, methods could be chained to send multiple messages in a row
+## 1.7.1 - 2021-02-01
+
+- Added `getConfig()` method to the `WeStacks\TeleBot\TeleBot` instance. It will return the passsed to the constructor config. [#8](https://github.com/westacks/telebot/issues/8)
+- Added ability to [change](https://westacks.github.io/telebot/#/configuration?id=standalone) `WeStacks\TeleBot\TeleBot`'s config parameters "on the go" using get/set syntax.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -47,3 +47,7 @@ All notable changes to `telebot` will be documented here
 - `WeStacks\TeleBot\Laravel\TelegramMessage` renamed to `WeStacks\TeleBot\Laravel\TelegramNotification`.
 - Telegram notification now can be sent only using `WeStacks\TeleBot\Laravel\TelegramNotification` object. Old array system is dropped
 - When sending notification using `WeStacks\TeleBot\Laravel\TelegramNotification`, methods could be chained to send multiple messages in a row
+## 1.7.1 - 2021-02-01
+
+- Added `getConfig()` method to the `WeStacks\TeleBot\TeleBot` instance. It will return the passsed to the constructor config. [#8](https://github.com/westacks/telebot/issues/8)
+- Added ability to [change](http://localhost:3000/#/configuration?id=standalone) `WeStacks\TeleBot\TeleBot`'s config parameters "on the go" using get/set syntax.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,16 @@ $bot = new TeleBot([
     'handlers'   => []
 ]);
 
-$bot->getMe();
+/** @var User */
+$user = $bot->getMe();
+
+// You may change all config parameters "on the go" using get/set syntax
+$bot->async = true; // Now bot uses A+ promises
+
+$bot->getMe()->then(function (User $user) {
+    var_dump($user);
+})->wait();
+
 ```
 
 #### ** Advanced **

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -73,6 +73,10 @@ Additional library methods:
     * Throw exceptions on next method, ignoring config parameter (bot method will throw `TeleBotRequestException` on request error)
     * Returns: `self`
 
+* **`getConfig()`**
+    * Get config that was used to create this bot instance
+    * Returns: `mixed`
+
 * **`handleUpdate(Update $update = null)`**
     * Handle Telegram [Update](https://core.telegram.org/bots/api#update) using registered update handlers. If given update is `null`, the library will try to create update from incoming `POST` request (in case you are using webhook). See more details in [Handling updates](updates.md) section
     * Returns: `Update|False` - given update, or `false` in case `Update` was not valid.

--- a/src/BotManager.php
+++ b/src/BotManager.php
@@ -103,6 +103,13 @@ use WeStacks\TeleBot\Objects\MessageId;
  * @method false|Update         handleUpdate(Update $update = null)                             Handle given update
  * @method BotCommand[]         getLocalCommands()                                              Get local bot instance commands registered by commands handlers
  * @method void                 callHandler($handler, Update $update, bool $force = false)      Run update handler.
+ * 
+ * 
+ * @method mixed                getConfig()                                                     Get config that was used to create this bot instance
+ * @property string $token Your telegram bot token.
+ * @property string $api_url API URL which will be used by library's HTTP client.
+ * @property bool $exceptions By default, bot throws TeleBotRequestException on telegram request errors. You may set this parameter false. In this case bot methods will return false instead of throwing exception.
+ * @property bool $async If you set this parameter true, bot methods will return Guzzle's A+ `PromiseInterface` object, which you can handle mannualy.
  */
 class BotManager
 {
@@ -136,6 +143,30 @@ class BotManager
     public function __call(string $name, array $arguments)
     {
         return $this->bot()->{$name}(...($arguments ?? []));
+    }
+
+    public function __get(string $name)
+    {
+        return $this->bot()->$name;
+    }
+
+    public function __set(string $name, $value)
+    {
+        if (!in_array($name, ['token', 'exceptions', 'async', 'api_url'])) {
+            throw TeleBotObjectException::inaccessibleVariable($name, self::class);
+        }
+
+        return $this->bot()->$name = $value;
+    }
+
+    public function __isset(string $key)
+    {
+        return isset($this->bot()->$key);
+    }
+
+    public function __unset(string $key)
+    {
+        throw TeleBotObjectException::inaccessibleUnsetVariable($key, self::class);
     }
 
     /**

--- a/src/Laravel/TeleBot.php
+++ b/src/Laravel/TeleBot.php
@@ -109,7 +109,9 @@ use WeStacks\TeleBot\TeleBot as Bot;
  * @method static void                                              callHandler($handler, Update $update, bool $force = false)                                                                                                     Run update handler.
  * @method static Update|False                                      handleUpdate(Update $update = null)                                                                                                                            Handle given update
  * @method static BotCommand[]                                      getLocalCommands()                                                                                                                                             Get local bot instance commands registered by commands handlers
- */
+ * 
+ * @method static mixed                                             getConfig()                                                                                                                                                    Get config that was used to create this bot instance
+*/
 class TeleBot extends Facade
 {
     /**

--- a/tests/Feature/HandleUpdatesTest.php
+++ b/tests/Feature/HandleUpdatesTest.php
@@ -4,6 +4,7 @@ namespace WeStacks\TeleBot\Tests\Feature;
 
 use PHPUnit\Framework\TestCase;
 use WeStacks\TeleBot\Exception\TeleBotMehtodException;
+use WeStacks\TeleBot\Exception\TeleBotObjectException;
 use WeStacks\TeleBot\Objects\BotCommand;
 use WeStacks\TeleBot\Objects\Update;
 use WeStacks\TeleBot\TeleBot;
@@ -101,5 +102,25 @@ class HandleUpdatesTest extends TestCase
     public function testNoUpdates()
     {
         $this->assertFalse($this->bot->handleUpdate());
+    }
+
+    public function testGetConfig()
+    {
+        $this->assertEquals(getenv('TELEGRAM_BOT_TOKEN'), $this->bot->getConfig());
+    }
+
+    public function testUpdateConfigOnGo()
+    {
+        $this->assertTrue($this->bot->exceptions);
+
+        $this->bot->exceptions = false;
+        $this->assertFalse($this->bot->exceptions);
+
+        $this->bot->exceptions = true;
+        $this->assertTrue($this->bot->exceptions);
+
+        $this->assertTrue(isset($this->bot->exceptions));
+        $this->expectException(TeleBotObjectException::class);
+        unset($this->bot->exceptions);
     }
 }

--- a/tests/Feature/LaravelTest.php
+++ b/tests/Feature/LaravelTest.php
@@ -13,6 +13,7 @@ use WeStacks\TeleBot\TeleBot as Bot;
 use WeStacks\TeleBot\Tests\Helpers\StartCommandHandler;
 use WeStacks\TeleBot\Tests\Helpers\TelegramNotification;
 use WeStacks\TeleBot\Tests\Helpers\TestNotifiable;
+use WeStacks\TeleBot\BotManager;
 
 class LaravelTest extends TestCase
 {
@@ -55,6 +56,24 @@ class LaravelTest extends TestCase
         }
         $this->expectException(TeleBotObjectException::class);
         TeleBot::bot('some_wrong_bot');
+    }
+
+    public function testBotManagerConfigs()
+    {
+        /** @var BotManager */
+        $manager = TeleBot::getFacadeRoot();
+        $this->assertTrue($manager->exceptions);
+
+        $manager->exceptions = false;
+        $this->assertFalse($manager->exceptions);
+
+        $manager->exceptions = true;
+        $this->assertTrue($manager->exceptions);
+
+        $this->assertTrue(isset($manager->exceptions));
+
+        $this->expectException(TeleBotObjectException::class);
+        unset($manager->exceptions);
     }
 
     public function testBotMenagerDefaultWrong()


### PR DESCRIPTION
- Added `getConfig()` method to the `WeStacks\TeleBot\TeleBot` instance. It will return the passsed to the constructor config. #8 
- Added ability to [change](https://westacks.github.io/telebot/#/configuration?id=standalone) `WeStacks\TeleBot\TeleBot`'s config parameters "on the go" using get/set syntax.