### PR TITLE
Fix Syntax error

### DIFF
--- a/src/Traits/HandlesUpdates.php
+++ b/src/Traits/HandlesUpdates.php
@@ -37,7 +37,7 @@ trait HandlesUpdates
      */
     public function clearHandlers()
     {
-        $this->kernel = new (get_class($this->kernel));
+        $this->kernel = new get_class($this->kernel);
     }
 
     /**


### PR DESCRIPTION
Fix syntax error at laravel 8. Unexpected '(' on line 40.