### PR TITLE
fix Typed property must not be accessed before initialization error in UpdateRequest class with 7.4+

### DIFF
--- a/src/Laravel/Requests/UpdateRequest.php
+++ b/src/Laravel/Requests/UpdateRequest.php
@@ -37,7 +37,7 @@ class UpdateRequest extends FormRequest
 
     public function update()
     {
-        if (!$this->update) {
+        if (empty($this->update)) {
             $this->update = new Update($this->validated());
         }
         return $this->update;


### PR DESCRIPTION
Since PHP 7.4 introduces type-hinting for properties, it is particularly important to provide valid values for all properties, so that all properties have values that match their declared types.
A property that has never been assigned doesn't have a null value, but it is on an undefined state, which will never match any declared type. undefined !== null.
so we can not check the status of a property in this way:
!$this->update