### PR TITLE
Bot api 7.2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,3 +136,6 @@ All notable changes to `telebot` will be documented in this file
 
 ## 3.2.0 - 2024-03-13
 - Updated [Bot API](https://core.telegram.org/bots/api) to version 7.1
+
+## 3.3.0 - 2024-04-01
+- Updated [Bot API](https://core.telegram.org/bots/api) to version 7.2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
 <a href="https://packagist.org/packages/westacks/telebot"><img src="https://poser.pugx.org/westacks/telebot/v/stable.svg" alt="Latest Stable Version"></a>
-<a href="https://core.telegram.org/bots/api"><img src="https://img.shields.io/badge/Bot%20API-7.1-blue" alt="Bot API Version"></a>
+<a href="https://core.telegram.org/bots/api"><img src="https://img.shields.io/badge/Bot%20API-7.2-blue" alt="Bot API Version"></a>
 <a href="https://packagist.org/packages/westacks/telebot"><img src="https://poser.pugx.org/westacks/telebot/d/total.svg" alt="Total Downloads"></a>
 <a href="https://packagist.org/packages/westacks/telebot"><img src="https://poser.pugx.org/westacks/telebot/license.svg" alt="License"></a>
 <a href="https://github.com/westacks/telebot/actions/workflows/main.yml"><img src="https://github.com/westacks/telebot/actions/workflows/main.yml/badge.svg" alt="PHPUnit"></a>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 <p id="telebot" align="center">
 <a href="https://github.com/westacks/telebot" class="app-name-link"><img src="/assets/logo.svg" alt="Project Logo"></a><br>
 <a href="https://packagist.org/packages/westacks/telebot"><img src="https://poser.pugx.org/westacks/telebot/v/stable.svg" alt="Latest Stable Version"></a>
-<a href="https://core.telegram.org/bots/api"><img src="https://img.shields.io/badge/Bot%20API-7.1-blue" alt="Bot API Version"></a>
+<a href="https://core.telegram.org/bots/api"><img src="https://img.shields.io/badge/Bot%20API-7.2-blue" alt="Bot API Version"></a>
 <a href="https://packagist.org/packages/westacks/telebot"><img src="https://poser.pugx.org/westacks/telebot/d/total.svg" alt="Total Downloads"></a>
 <a href="https://packagist.org/packages/westacks/telebot"><img src="https://poser.pugx.org/westacks/telebot/license.svg" alt="License"></a>
 </p>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -136,3 +136,6 @@ All notable changes to `telebot` will be documented here
 
 ## 3.2.0 - 2024-03-13
 - Updated [Bot API](https://core.telegram.org/bots/api) to version 7.1
+
+## 3.3.0 - 2024-04-01
+- Updated [Bot API](https://core.telegram.org/bots/api) to version 7.2

--- a/src/Methods/CreateNewStickerSetMethod.php
+++ b/src/Methods/CreateNewStickerSetMethod.php
@@ -12,7 +12,6 @@ use WeStacks\TeleBot\Objects\InputSticker;
  * @property string         $name             __Required: Yes__. Short name of sticker set, to be used in t.me/addstickers/ URLs (e.g., animals). Can contain only english letters, digits and underscores. Must begin with a letter, can't contain consecutive underscores and must end in “_by_”.  is case insensitive. 1-64 characters.
  * @property string         $title            __Required: Yes__. Sticker set title, 1-64 characters
  * @property InputSticker[] $stickers         __Required: Yes__. A JSON-serialized list of 1-50 initial stickers to be added to the sticker set
- * @property string         $sticker_format   __Required: Yes__. Format of stickers in the set, must be one of “static”, “animated”, “video”
  * @property string         $sticker_type     __Required: Optional__. Type of stickers in the set, pass “regular”, “mask”, or “custom_emoji”. By default, a regular sticker set is created.
  * @property true           $needs_repainting __Required: Optional__. Pass True if stickers in the sticker set must be repainted to the color of text when used in messages, the accent color if used as emoji status, white on chat photos, or another appropriate color based on context; for custom emoji sticker sets only
  */
@@ -27,7 +26,6 @@ class CreateNewStickerSetMethod extends TelegramMethod
         'name' => 'string',
         'title' => 'string',
         'stickers' => 'InputSticker[]',
-        'sticker_format' => 'string',
         'sticker_type' => 'string',
         'needs_repainting' => 'boolean',
     ];

--- a/src/Methods/DeleteMessagesMethod.php
+++ b/src/Methods/DeleteMessagesMethod.php
@@ -18,7 +18,7 @@ class DeleteMessagesMethod extends TelegramMethod
 
     protected array $parameters = [
         'chat_id' => 'string',
-        'message_id' => 'integer[]',
+        'message_ids' => 'integer[]',
     ];
 
     public function mock($arguments)

--- a/src/Methods/GetBusinessConnectionMethod.php
+++ b/src/Methods/GetBusinessConnectionMethod.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace WeStacks\TeleBot\Methods;
+
+use WeStacks\TeleBot\Contracts\TelegramMethod;
+use WeStacks\TeleBot\Objects\BusinessConnection;
+
+/**
+ * Use this method to get information about the connection of the bot with a business account. Returns a [BusinessConnection](https://core.telegram.org/bots/api#businessconnection) object on success.
+ *
+ * @property string $business_connection_id __Required: Yes__. Unique identifier of the business connection
+ */
+class GetBusinessConnectionMethod extends TelegramMethod
+{
+    protected string $method = 'getBusinessConnection';
+
+    protected string $expect = 'BusinessConnection';
+
+    protected array $parameters = [
+        'business_connection_id' => 'string',
+    ];
+
+    public function mock($arguments)
+    {
+        return BusinessConnection::create([
+            'id' => '123456789',
+            'user' => [
+                'id' => $arguments['user_id'],
+                'first_name' => 'First',
+                'last_name' => 'Last',
+                'username' => 'username',
+            ],
+            'user_chat_id' => 123456789,
+            'date' => time(),
+            'can_reply' => true,
+            'is_enabled' => true,
+        ]);
+    }
+}

--- a/src/Methods/ReplaceStickerInSet.php
+++ b/src/Methods/ReplaceStickerInSet.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace WeStacks\TeleBot\Methods;
+
+use WeStacks\TeleBot\Contracts\TelegramMethod;
+use WeStacks\TeleBot\Objects\InputSticker;
+
+/**
+ * Use this method to replace an existing sticker in a sticker set with a new one. The method is equivalent to calling [deleteStickerFromSet](https://core.telegram.org/bots/api#deletestickerfromset), then [addStickerToSet](https://core.telegram.org/bots/api#addstickertoset), then [setStickerPositionInSet](https://core.telegram.org/bots/api#setstickerpositioninset). Returns True on success.
+ *
+ * @property int          $user_id     __Required: Yes__. User identifier of the sticker set owner
+ * @property string       $name        __Required: Yes__. Sticker set name
+ * @property string       $old_sticker __Required: Yes__. File identifier of the replaced sticker
+ * @property InputSticker $sticker     __Required: Yes__. A JSON-serialized object with information about the added sticker. If exactly the same sticker had already been added to the set, then the set remains unchanged.
+ */
+class ReplaceStickerInSet extends TelegramMethod
+{
+    protected string $method = 'replaceStickerInSet';
+
+    protected string $expect = 'boolean';
+
+    protected array $parameters = [
+        'user_id' => 'integer',
+        'name' => 'string',
+        'old_sticker' => 'string',
+        'sticker' => 'InputSticker',
+    ];
+
+    public function mock($arguments)
+    {
+        return true;
+    }
+}

--- a/src/Methods/SendChatActionMethod.php
+++ b/src/Methods/SendChatActionMethod.php
@@ -11,9 +11,10 @@ use WeStacks\TeleBot\Contracts\TelegramMethod;
  *
  * We only recommend using this method when a response from the bot will take a noticeable amount of time to arrive.
  *
- * @property string $chat_id           __Required: Yes__. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
- * @property string $message_thread_id __Required: Optional__. Unique identifier for the target message thread; supergroups only
- * @property string $action            __Required: Yes__. Type of action to broadcast. Choose one, depending on what the user is about to receive: typing for text messages, upload_photo for photos, record_video or upload_video for videos, record_voice or upload_voice for voice notes, upload_document for general files, choose_sticker for stickers, find_location for location data, record_video_note or upload_video_note for video notes.
+ * @property string $business_connection_id __Required: Optional__. Unique identifier of the business connection on behalf of which the message will be sent
+ * @property string $chat_id                __Required: Yes__. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+ * @property string $message_thread_id      __Required: Optional__. Unique identifier for the target message thread; supergroups only
+ * @property string $action                 __Required: Yes__. Type of action to broadcast. Choose one, depending on what the user is about to receive: typing for text messages, upload_photo for photos, record_video or upload_video for videos, record_voice or upload_voice for voice notes, upload_document for general files, choose_sticker for stickers, find_location for location data, record_video_note or upload_video_note for video notes.
  */
 class SendChatActionMethod extends TelegramMethod
 {
@@ -22,6 +23,7 @@ class SendChatActionMethod extends TelegramMethod
     protected string $expect = 'boolean';
 
     protected array $parameters = [
+        'bussiness_connection_id' => 'string',
         'chat_id' => 'string',
         'message_thread_id' => 'integer',
         'action' => 'string',

--- a/src/Methods/SendContactMethod.php
+++ b/src/Methods/SendContactMethod.php
@@ -10,16 +10,16 @@ use WeStacks\TeleBot\Objects\ReplyParameters;
 /**
  * Use this method to send phone contacts. On success, the sent [Message](https://core.telegram.org/bots/api#message) is returned.
  *
- * @property string   $chat_id                     __Required: Yes__. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
- * @property int      $message_thread_id           __Required: Optional__. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
- * @property string   $phone_number                __Required: Yes__. Contact's phone number
- * @property string   $first_name                  __Required: Yes__. Contact's first name
- * @property string   $last_name                   __Required: Optional__. Contact's last name
- * @property string   $vcard                       __Required: Optional__. Additional data about the contact in the form of a vCard, 0-2048 bytes
- * @property bool     $disable_notification        __Required: Optional__. Sends the message silently. Users will receive a notification with no sound.
- * @property bool     $protect_content             __Required: Optional__. Protects the contents of the sent message from forwarding and saving
+ * @property string          $business_connection_id      __Required: Optional__. Unique identifier of the business connection on behalf of which the message will be sent* @property string   $chat_id                     __Required: Yes__. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+ * @property int             $message_thread_id           __Required: Optional__. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+ * @property string          $phone_number                __Required: Yes__. Contact's phone number
+ * @property string          $first_name                  __Required: Yes__. Contact's first name
+ * @property string          $last_name                   __Required: Optional__. Contact's last name
+ * @property string          $vcard                       __Required: Optional__. Additional data about the contact in the form of a vCard, 0-2048 bytes
+ * @property bool            $disable_notification        __Required: Optional__. Sends the message silently. Users will receive a notification with no sound.
+ * @property bool            $protect_content             __Required: Optional__. Protects the contents of the sent message from forwarding and saving
  * @property ReplyParameters $reply_parameters            __Required: Optional__. Description of the message to reply to
- * @property Keyboard $reply_markup                __Required: Optional__. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove keyboard or to force a reply from the user.
+ * @property Keyboard        $reply_markup                __Required: Optional__. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove keyboard or to force a reply from the user.
  */
 class SendContactMethod extends TelegramMethod
 {
@@ -28,6 +28,7 @@ class SendContactMethod extends TelegramMethod
     protected string $expect = 'Message';
 
     protected array $parameters = [
+        'bussiness_connection_id' => 'string',
         'chat_id' => 'string',
         'message_thread_id' => 'integer',
         'phone_number' => 'string',

--- a/src/Methods/SendDiceMethod.php
+++ b/src/Methods/SendDiceMethod.php
@@ -10,13 +10,14 @@ use WeStacks\TeleBot\Objects\ReplyParameters;
 /**
  * Use this method to send an animated emoji that will display a random value. On success, the sent [Message](https://core.telegram.org/bots/api#message) is returned.
  *
- * @property string   $chat_id                     __Required: Yes__. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
- * @property int      $message_thread_id           __Required: Optional__. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
- * @property string   $emoji                       __Required: Optional__. Emoji on which the dice throw animation is based. Currently, must be one of “🎲”, “🎯”, “🏀”, “⚽”, or “🎰”. Dice can have values 1-6 for “🎲” and “🎯”, values 1-5 for “🏀” and “⚽”, and values 1-64 for “🎰”. Defaults to “🎲”
- * @property bool     $disable_notification        __Required: Optional__. Sends the message silently. Users will receive a notification with no sound.
- * @property bool     $protect_content             __Required: Optional__. Protects the contents of the sent message from forwarding
+ * @property string          $business_connection_id      __Required: Optional__. Unique identifier of the business connection on behalf of which the message will be sent
+ * @property string          $chat_id                     __Required: Yes__. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+ * @property int             $message_thread_id           __Required: Optional__. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+ * @property string          $emoji                       __Required: Optional__. Emoji on which the dice throw animation is based. Currently, must be one of “🎲”, “🎯”, “🏀”, “⚽”, or “🎰”. Dice can have values 1-6 for “🎲” and “🎯”, values 1-5 for “🏀” and “⚽”, and values 1-64 for “🎰”. Defaults to “🎲”
+ * @property bool            $disable_notification        __Required: Optional__. Sends the message silently. Users will receive a notification with no sound.
+ * @property bool            $protect_content             __Required: Optional__. Protects the contents of the sent message from forwarding
  * @property ReplyParameters $reply_parameters            __Required: Optional__. Description of the message to reply to
- * @property Keyboard $reply_markup                __Required: Optional__. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+ * @property Keyboard        $reply_markup                __Required: Optional__. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
  */
 class SendDiceMethod extends TelegramMethod
 {
@@ -25,6 +26,7 @@ class SendDiceMethod extends TelegramMethod
     protected string $expect = 'Message';
 
     protected array $parameters = [
+        'bussiness_connection_id' => 'string',
         'chat_id' => 'string',
         'message_thread_id' => 'integer',
         'emoji' => 'string',

--- a/src/Methods/SendGameMethod.php
+++ b/src/Methods/SendGameMethod.php
@@ -10,7 +10,7 @@ use WeStacks\TeleBot\Objects\ReplyParameters;
 /**
  * Use this method to send a game. On success, the sent [Message](https://core.telegram.org/bots/api#message) is returned.
  *
- * @property int                  $chat_id                     __Required: Yes__. Unique identifier for the target chat
+ * @property string               $business_connection_id      __Required: Optional__. Unique identifier of the business connection on behalf of which the message will be sent* @property int                  $chat_id                     __Required: Yes__. Unique identifier for the target chat
  * @property int                  $message_thread_id           __Required: Optional__. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
  * @property string               $game_short_name             __Required: Yes__. Short name of the game, serves as the unique identifier for the game. Set up your games via Botfather.
  * @property bool                 $disable_notification        __Required: Optional__. Sends the message silently. Users will receive a notification with no sound.
@@ -25,6 +25,7 @@ class SendGameMethod extends TelegramMethod
     protected string $expect = 'Message';
 
     protected array $parameters = [
+        'bussiness_connection_id' => 'string',
         'chat_id' => 'integer',
         'message_thread_id' => 'integer',
         'game_short_name' => 'string',

--- a/src/Methods/SendLocationMethod.php
+++ b/src/Methods/SendLocationMethod.php
@@ -10,18 +10,19 @@ use WeStacks\TeleBot\Objects\ReplyParameters;
 /**
  * Use this method to send point on the map. On success, the sent [Message](https://core.telegram.org/bots/api#message) is returned.
  *
- * @property string   $chat_id                     __Required: Yes__. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
- * @property int      $message_thread_id           __Required: Optional__. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
- * @property float    $latitude                    __Required: Yes__. Latitude of the location
- * @property float    $longitude                   __Required: Yes__. Longitude of the location
- * @property float    $horizontal_accuracy         __Required: Optional__. The radius of uncertainty for the location, measured in meters; 0-1500
- * @property int      $live_period                 __Required: Optional__. Period in seconds for which the location will be updated (see Live Locations, should be between 60 and 86400.
- * @property int      $heading                     __Required: Optional__. For live locations, a direction in which the user is moving, in degrees. Must be between 1 and 360 if specified.
- * @property int      $proximity_alert_radius      __Required: Optional__. For live locations, a maximum distance for proximity alerts about approaching another chat member, in meters. Must be between 1 and 100000 if specified.
- * @property bool     $disable_notification        __Required: Optional__. Sends the message silently. Users will receive a notification with no sound.
- * @property bool     $protect_content             __Required: Optional__. Protects the contents of the sent message from forwarding and saving
+ * @property string          $business_connection_id      __Required: Optional__. Unique identifier of the business connection on behalf of which the message will be sent
+ * @property string          $chat_id                     __Required: Yes__. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+ * @property int             $message_thread_id           __Required: Optional__. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+ * @property float           $latitude                    __Required: Yes__. Latitude of the location
+ * @property float           $longitude                   __Required: Yes__. Longitude of the location
+ * @property float           $horizontal_accuracy         __Required: Optional__. The radius of uncertainty for the location, measured in meters; 0-1500
+ * @property int             $live_period                 __Required: Optional__. Period in seconds for which the location will be updated (see Live Locations, should be between 60 and 86400.
+ * @property int             $heading                     __Required: Optional__. For live locations, a direction in which the user is moving, in degrees. Must be between 1 and 360 if specified.
+ * @property int             $proximity_alert_radius      __Required: Optional__. For live locations, a maximum distance for proximity alerts about approaching another chat member, in meters. Must be between 1 and 100000 if specified.
+ * @property bool            $disable_notification        __Required: Optional__. Sends the message silently. Users will receive a notification with no sound.
+ * @property bool            $protect_content             __Required: Optional__. Protects the contents of the sent message from forwarding and saving
  * @property ReplyParameters $reply_parameters            __Required: Optional__. Description of the message to reply to
- * @property Keyboard $reply_markup                __Required: Optional__. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+ * @property Keyboard        $reply_markup                __Required: Optional__. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
  */
 class SendLocationMethod extends TelegramMethod
 {
@@ -30,6 +31,7 @@ class SendLocationMethod extends TelegramMethod
     protected string $expect = 'Message';
 
     protected array $parameters = [
+        'bussiness_connection_id' => 'string',
         'chat_id' => 'string',
         'message_thread_id' => 'integer',
         'latitude' => 'double',

--- a/src/Methods/SendMediaGroupMethod.php
+++ b/src/Methods/SendMediaGroupMethod.php
@@ -3,18 +3,20 @@
 namespace WeStacks\TeleBot\Methods;
 
 use WeStacks\TeleBot\Contracts\TelegramMethod;
+use WeStacks\TeleBot\Objects\InputMedia;
 use WeStacks\TeleBot\Objects\Message;
 use WeStacks\TeleBot\Objects\ReplyParameters;
 
 /**
  * Use this method to send a group of photos, videos, documents or audios as an album. Documents and audio files can be only grouped in an album with messages of the same type. On success, an array of [Messages](https://core.telegram.org/bots/api#message) that were sent is returned.
  *
+ * @property string          $business_connection_id      __Required: Optional__. Unique identifier of the business connection on behalf of which the message will be sent
  * @property string          $chat_id                     __Required: Yes__. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @property int             $message_thread_id           __Required: Optional__. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
  * @property InputMedia[]    $media                       __Required: Yes__. A JSON-serialized array describing messages to be sent, must include 2-10 items
  * @property bool            $disable_notification        __Required: Optional__. Sends messages silently. Users will receive a notification with no sound.
  * @property bool            $protect_content             __Required: Optional__. Protects the contents of the sent messages from forwarding and saving
- * @property ReplyParameters $reply_parameters           __Required: Optional__. Description of the message to reply to
+ * @property ReplyParameters $reply_parameters            __Required: Optional__. Description of the message to reply to
  */
 class SendMediaGroupMethod extends TelegramMethod
 {
@@ -23,6 +25,7 @@ class SendMediaGroupMethod extends TelegramMethod
     protected string $expect = 'Message[]';
 
     protected array $parameters = [
+        'bussiness_connection_id' => 'string',
         'chat_id' => 'string',
         'message_thread_id' => 'integer',
         'media' => 'InputMedia[]',

--- a/src/Methods/SendMessageMethod.php
+++ b/src/Methods/SendMessageMethod.php
@@ -12,16 +12,17 @@ use WeStacks\TeleBot\Objects\LinkPreviewOptions;
 /**
  * Use this method to send text messages. On success, the sent [Message](https://core.telegram.org/bots/api#message) is returned.
  *
- * @property string          $chat_id                     __Required: Yes__. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
- * @property int             $message_thread_id           __Required: Optional__. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
- * @property string          $text                        __Required: Yes__. Text of the message to be sent, 1-4096 characters after entities parsing
- * @property string          $parse_mode                  __Required: Optional__. Mode for parsing entities in the message text. See formatting options for more details.
- * @property MessageEntity[] $entities                    __Required: Optional__. A JSON-serialized list of special entities that appear in message text, which can be specified instead of parse_mode
- * @property LinkPreviewOptions   $link_preview_options     __Required: Optional__. Link preview generation options for the message
- * @property bool            $disable_notification        __Required: Optional__. Sends the message silently. Users will receive a notification with no sound.
- * @property bool            $protect_content             __Required: Optional__. Protects the contents of the sent message from forwarding and saving
- * @property ReplyParameters $reply_parameters            __Required: Optional__. Description of the message to reply to
- * @property Keyboard        $reply_markup                __Required: Optional__. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+ * @property string             $business_connection_id      __Required: Optional__. Unique identifier of the business connection on behalf of which the message will be sent
+ * @property string             $chat_id                     __Required: Yes__. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+ * @property int                $message_thread_id           __Required: Optional__. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+ * @property string             $text                        __Required: Yes__. Text of the message to be sent, 1-4096 characters after entities parsing
+ * @property string             $parse_mode                  __Required: Optional__. Mode for parsing entities in the message text. See formatting options for more details.
+ * @property MessageEntity[]    $entities                    __Required: Optional__. A JSON-serialized list of special entities that appear in message text, which can be specified instead of parse_mode
+ * @property LinkPreviewOptions $link_preview_options        __Required: Optional__. Link preview generation options for the message
+ * @property bool               $disable_notification        __Required: Optional__. Sends the message silently. Users will receive a notification with no sound.
+ * @property bool               $protect_content             __Required: Optional__. Protects the contents of the sent message from forwarding and saving
+ * @property ReplyParameters    $reply_parameters            __Required: Optional__. Description of the message to reply to
+ * @property Keyboard           $reply_markup                __Required: Optional__. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
  */
 class SendMessageMethod extends TelegramMethod
 {
@@ -30,6 +31,7 @@ class SendMessageMethod extends TelegramMethod
     protected string $expect = 'Message';
 
     protected array $parameters = [
+        'bussiness_connection_id' => 'string',
         'chat_id' => 'string',
         'message_thread_id' => 'integer',
         'text' => 'string',

--- a/src/Methods/SendPollMethod.php
+++ b/src/Methods/SendPollMethod.php
@@ -11,7 +11,7 @@ use WeStacks\TeleBot\Objects\ReplyParameters;
 /**
  * Use this method to send a native poll. On success, the sent [Message](https://core.telegram.org/bots/api#message) is returned.
  *
- * @property string          $chat_id                     __Required: Yes__. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+ * @property string          $business_connection_id      __Required: Optional__. Unique identifier of the business connection on behalf of which the message will be sent* @property string          $chat_id                     __Required: Yes__. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @property int             $message_thread_id           __Required: Optional__. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
  * @property string          $question                    __Required: Yes__. Poll question, 1-300 characters
  * @property string[]        $options                     __Required: Yes__. A JSON-serialized list of answer options, 2-10 strings 1-100 characters each
@@ -37,6 +37,7 @@ class SendPollMethod extends TelegramMethod
     protected string $expect = 'Message';
 
     protected array $parameters = [
+        'bussiness_connection_id' => 'string',
         'chat_id' => 'string',
         'message_thread_id' => 'integer',
         'question' => 'string',

--- a/src/Methods/SendStickerMethod.php
+++ b/src/Methods/SendStickerMethod.php
@@ -11,9 +11,10 @@ use WeStacks\TeleBot\Objects\ReplyParameters;
 /**
  * Use this method to send static .WEBP or [animated](https://telegram.org/blog/animated-stickers) .TGS stickers. On success, the sent [Message](https://core.telegram.org/bots/api#message) is returned.
  *
+ * @property string          $business_connection_id      __Required: Optional__. Unique identifier of the business connection on behalf of which the message will be sent
  * @property string          $chat_id                     __Required: Yes__. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @property int             $message_thread_id           __Required: Optional__. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
- * @property InputFile       $sticker                     __Required: Yes__. Sticker to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a .WEBP file from the Internet, or upload a new one using multipart/form-data. More info on Sending Files »
+ * @property InputFile       $sticker                     __Required: Yes__. Sticker to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a .WEBP sticker from the Internet, or upload a new .WEBP, .TGS, or .WEBM sticker using multipart/form-data. More information on Sending Files ». Video and animated stickers can't be sent via an HTTP URL.
  * @property string          $emoji                       __Required: Optional__. Emoji associated with the sticker; only for just uploaded stickers
  * @property bool            $disable_notification        __Required: Optional__. Sends the message silently. Users will receive a notification with no sound.
  * @property bool            $protect_content             __Required: Optional__. Protects the contents of the sent message from forwarding and saving
@@ -27,6 +28,7 @@ class SendStickerMethod extends TelegramMethod
     protected string $expect = 'Message';
 
     protected array $parameters = [
+        'bussiness_connection_id' => 'string',
         'chat_id' => 'string',
         'message_thread_id' => 'integer',
         'sticker' => 'InputFile',

--- a/src/Methods/SendVenueMethod.php
+++ b/src/Methods/SendVenueMethod.php
@@ -10,20 +10,21 @@ use WeStacks\TeleBot\Objects\ReplyParameters;
 /**
  * Use this method to send information about a venue. On success, the sent [Message](https://core.telegram.org/bots/api#message) is returned.
  *
- * @property string   $chat_id                     __Required: Yes__. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
- * @property int      $message_thread_id           __Required: Optional__. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
- * @property float    $latitude                    __Required: Yes__. Latitude of the venue
- * @property float    $longitude                   __Required: Yes__. Longitude of the venue
- * @property string   $title                       __Required: Yes__. Name of the venue
- * @property string   $address                     __Required: Yes__. Address of the venue
- * @property string   $foursquare_id               __Required: Optional__. Foursquare identifier of the venue
- * @property string   $foursquare_type             __Required: Optional__. Foursquare type of the venue, if known. (For example, “arts_entertainment/default”, “arts_entertainment/aquarium” or “food/icecream”.)
- * @property string   $google_place_id             __Required: Optional__. Google Places identifier of the venue
- * @property string   $google_place_type           __Required: Optional__. Google Places type of the venue. (See supported types.)
- * @property bool     $disable_notification        __Required: Optional__. Sends the message silently. Users will receive a notification with no sound.
- * @property bool     $protect_content             __Required: Optional__. Protects the contents of the sent message from forwarding and saving
+ * @property string          $business_connection_id      __Required: Optional__. Unique identifier of the business connection on behalf of which the message will be sent
+ * @property string          $chat_id                     __Required: Yes__. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+ * @property int             $message_thread_id           __Required: Optional__. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+ * @property float           $latitude                    __Required: Yes__. Latitude of the venue
+ * @property float           $longitude                   __Required: Yes__. Longitude of the venue
+ * @property string          $title                       __Required: Yes__. Name of the venue
+ * @property string          $address                     __Required: Yes__. Address of the venue
+ * @property string          $foursquare_id               __Required: Optional__. Foursquare identifier of the venue
+ * @property string          $foursquare_type             __Required: Optional__. Foursquare type of the venue, if known. (For example, “arts_entertainment/default”, “arts_entertainment/aquarium” or “food/icecream”.)
+ * @property string          $google_place_id             __Required: Optional__. Google Places identifier of the venue
+ * @property string          $google_place_type           __Required: Optional__. Google Places type of the venue. (See supported types.)
+ * @property bool            $disable_notification        __Required: Optional__. Sends the message silently. Users will receive a notification with no sound.
+ * @property bool            $protect_content             __Required: Optional__. Protects the contents of the sent message from forwarding and saving
  * @property ReplyParameters $reply_parameters            __Required: Optional__. Description of the message to reply to
- * @property Keyboard $reply_markup                __Required: Optional__. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+ * @property Keyboard        $reply_markup                __Required: Optional__. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
  */
 class SendVenueMethod extends TelegramMethod
 {
@@ -32,6 +33,7 @@ class SendVenueMethod extends TelegramMethod
     protected string $expect = 'Message';
 
     protected array $parameters = [
+        'bussiness_connection_id' => 'string',
         'chat_id' => 'string',
         'message_thread_id' => 'integer',
         'latitude' => 'double',

--- a/src/Methods/SendVoiceMethod.php
+++ b/src/Methods/SendVoiceMethod.php
@@ -12,6 +12,7 @@ use WeStacks\TeleBot\Objects\ReplyParameters;
 /**
  * Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message. For this to work, your audio must be in an .OGG file encoded with OPUS (other formats may be sent as [Audio](https://core.telegram.org/bots/api#audio) or [Document](https://core.telegram.org/bots/api#document)). On success, the sent [Message](https://core.telegram.org/bots/api#message) is returned. Bots can currently send voice messages of up to 50 MB in size, this limit may be changed in the future.
  *
+ * @property string          $business_connection_id      __Required: Optional__. Unique identifier of the business connection on behalf of which the message will be sent
  * @property string          $chat_id                     __Required: Yes__. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  * @property int             $message_thread_id           __Required: Optional__. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
  * @property InputFile       $voice                       __Required: Yes__. Audio file to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data. More info on Sending Files »
@@ -31,6 +32,7 @@ class SendVoiceMethod extends TelegramMethod
     protected string $expect = 'Message';
 
     protected array $parameters = [
+        'bussiness_connection_id' => 'string',
         'chat_id' => 'string',
         'message_thread_id' => 'integer',
         'voice' => 'InputFile',

--- a/src/Methods/SetStickerSetThumbnailMethod.php
+++ b/src/Methods/SetStickerSetThumbnailMethod.php
@@ -11,6 +11,7 @@ use WeStacks\TeleBot\Objects\InputFile;
  * @property string    $name      __Required: Yes__. Sticker set name
  * @property int       $user_id   __Required: Yes__. User identifier of the sticker set owner
  * @property InputFile $thumbnail __Required: Optional__. A PNG image with the thumbnail, must be up to 128 kilobytes in size and have width and height exactly 100px, or a TGS animation with the thumbnail up to 32 kilobytes in size; see https://core.telegram.org/animated_stickers#technical-requirements for animated sticker technical requirements. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data. More info on Sending Files ». Animated sticker set thumbnail can't be uploaded via HTTP URL.
+ * @property string    $format    __Required: Yes__. Format of the thumbnail, must be one of “static” for a .WEBP or .PNG image, “animated” for a .TGS animation, or “video” for a WEBM video
  */
 class SetStickerSetThumbnailMethod extends TelegramMethod
 {
@@ -22,6 +23,7 @@ class SetStickerSetThumbnailMethod extends TelegramMethod
         'name' => 'string',
         'user_id' => 'string',
         'thumbnail' => 'InputFile',
+        'format' => 'string',
     ];
 
     public function mock($arguments)

--- a/src/Objects/Birthdate.php
+++ b/src/Objects/Birthdate.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace WeStacks\TeleBot\Objects;
+
+use WeStacks\TeleBot\Contracts\TelegramObject;
+
+/**
+ * This object represents a birthday class.
+ *
+ * @property int $day   Day of the user's birth; 1-31
+ * @property int $month Month of the user's birth; 1-12
+ * @property int $year  Optional. Year of the user's birth
+ */
+class Birthdate extends TelegramObject
+{
+    protected $attributes = [
+        'day' => 'integer',
+        'month' => 'integer',
+        'year' => 'integer',
+    ];
+}

--- a/src/Objects/BusinessConnection.php
+++ b/src/Objects/BusinessConnection.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace WeStacks\TeleBot\Objects;
+
+use WeStacks\TeleBot\Contracts\TelegramObject;
+
+/**
+ * Describes the connection of the bot with a business account.
+ *
+ * @property string $id            Unique identifier of the business connection
+ * @property User   $user          Business account user that created the business connection
+ * @property int    $user_chat_id  Identifier of a private chat with the user who created the business connection. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier.
+ * @property int    $date          Date the connection was established in Unix time
+ * @property bool   $can_reply     True, if the bot can act on behalf of the business account in chats that were active in the last 24 hours
+ * @property bool   $is_enabled    True, if the connection is active
+ */
+class BusinessConnection extends TelegramObject
+{
+    protected $attributes = [
+        'id' => 'string',
+        'user' => 'User',
+        'user_chat_id' => 'integer',
+        'date' => 'integer',
+        'can_reply' => 'boolean',
+        'is_enabled' => 'boolean',
+    ];
+}

--- a/src/Objects/BusinessIntro.php
+++ b/src/Objects/BusinessIntro.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace WeStacks\TeleBot\Objects;
+
+/**
+ * This object represents the opening hours of the business.
+ *
+ * @property string  $title     Optional. Title text of the business intro
+ * @property string  $message   Optional. Message text of the business intro
+ * @property Sticker $sticker   Optional. Sticker of the business intro
+ */
+class BusinessIntro extends ReactionType
+{
+    protected $attributes = [
+        'title' => 'string',
+        'message' => 'string',
+        'sticker' => 'Sticker',
+    ];
+}

--- a/src/Objects/BusinessLocation.php
+++ b/src/Objects/BusinessLocation.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace WeStacks\TeleBot\Objects;
+
+/**
+ * This object represents the location of the business.
+ *
+ * @property string   $address     Address of the business
+ * @property Location $location    Optional. Location of the business
+ */
+class BusinessLocation extends ReactionType
+{
+    protected $attributes = [
+        'address' => 'string',
+        'location' => 'Location',
+    ];
+}

--- a/src/Objects/BusinessMessagesDeleted.php
+++ b/src/Objects/BusinessMessagesDeleted.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace WeStacks\TeleBot\Objects;
+
+use WeStacks\TeleBot\Contracts\TelegramObject;
+
+/**
+ * This object is received when messages are deleted from a connected business account.
+ *
+ * @property string $business_connection_id Unique identifier of the business connection
+ * @property Chat   $chat                   Information about a chat in the business account. The bot may not have access to the chat or the corresponding user.
+ * @property int[]  $message_ids            A JSON-serialized list of identifiers of deleted messages in the chat of the business account
+ */
+class BusinessMessagesDeleted extends TelegramObject
+{
+    protected $attributes = [
+        'business_connection_id' => 'string',
+        'chat' => 'Chat',
+        'message_ids' => 'integer[]',
+    ];
+}

--- a/src/Objects/BusinessOpeningHours.php
+++ b/src/Objects/BusinessOpeningHours.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace WeStacks\TeleBot\Objects;
+
+/**
+ * This object represents the opening hours of the place
+ *
+ * @property string                         $time_zone_name  Unique name of the time zone for which the opening hours are defined
+ * @property BusinessOpeningHoursInterval[] $opening_hours   List of time intervals describing business opening hours
+ */
+class BusinessOpeningHours extends ReactionType
+{
+    protected $attributes = [
+        'time_zone_name' => 'string',
+        'opening_hours' => 'BusinessOpeningHoursInterval[]',
+    ];
+}

--- a/src/Objects/BusinessOpeningHoursInterval.php
+++ b/src/Objects/BusinessOpeningHoursInterval.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace WeStacks\TeleBot\Objects;
+
+/**
+ * This object represents one interval of the opening hours
+ *
+ * @property int $opening_minute  The minute's sequence number in a week, starting on Monday, marking the start of the time interval during which the business is open; 0 - 7 24 60
+ * @property int $closing_minute  The minute's sequence number in a week, starting on Monday, marking the end of the time interval during which the business is open; 0 - 8 24 60
+ */
+class BusinessOpeningHoursInterval extends ReactionType
+{
+    protected $attributes = [
+        'opening_minute' => 'integer',
+        'closing_minute' => 'integer',
+    ];
+}

--- a/src/Objects/Chat.php
+++ b/src/Objects/Chat.php
@@ -7,43 +7,48 @@ use WeStacks\TeleBot\Contracts\TelegramObject;
 /**
  * This object represents a chat.
  *
- * @property int             $id                                        Unique identifier for this chat. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or double-precision float type are safe for storing this identifier.
- * @property string          $type                                      Type of chat, can be either “private”, “group”, “supergroup” or “channel”
- * @property string          $title                                     Optional. Title, for supergroups, channels and group chats
- * @property string          $username                                  Optional. Username, for private chats, supergroups and channels if available
- * @property string          $first_name                                Optional. First name of the other party in a private chat
- * @property string          $last_name                                 Optional. Last name of the other party in a private chat
- * @property bool            $is_forum                                  Optional. True, if the supergroup chat is a forum (has topics enabled)
- * @property ChatPhoto       $photo                                     Optional. Chat photo. Returned only in getChat.
- * @property string[]        $active_usernames                          Optional. If non-empty, the list of all active chat usernames; for private chats, supergroups and channels. Returned only in getChat.
- * @property ReactionType[]  $available_reactions                       Optional. List of available reactions allowed in the chat. If omitted, then all emoji reactions are allowed. Returned only in getChat.
- * @property int             $accent_color_id                           Optional. Identifier of the accent color for the chat name and backgrounds of the chat photo, reply header, and link preview. See accent colors for more details. Returned only in getChat. Always returned in getChat.
- * @property string          $background_custom_emoji_id                Optional. Custom emoji identifier of emoji chosen by the chat for the reply header and link preview background. Returned only in getChat.
- * @property int             $profile_accent_color_id                   Optional. Identifier of the accent color for the chat's profile background. See profile accent colors for more details. Returned only in getChat.
- * @property string          $profile_background_custom_emoji_id        Optional. Custom emoji identifier of the emoji chosen by the chat for its profile background. Returned only in getChat.
- * @property string          $emoji_status_custom_emoji_id              Optional. Custom emoji identifier of the emoji status of the chat or the other party in a private chat. Returned only in getChat.
- * @property int             $emoji_status_expiration_date              Optional. Expiration date of the emoji status of the chat or the other party in a private chat, in Unix time, if any. Returned only in getChat.
- * @property string          $bio                                       Optional. Bio of the other party in a private chat. Returned only in getChat.
- * @property bool            $has_private_forwards                      Optional. True, if privacy settings of the other party in the private chat allows to use tg://user?id= links only in chats with the user. Returned only in getChat.
- * @property bool            $has_restricted_voice_and_video_messages   Optional. True, if the privacy settings of the other party restrict sending voice and video note messages in the private chat. Returned only in getChat.
- * @property bool            $join_to_send_messages                     Optional. True, if users need to join the supergroup before they can send messages. Returned only in getChat.
- * @property bool            $join_by_request                           Optional. True, if all users directly joining the supergroup need to be approved by supergroup administrators. Returned only in getChat.
- * @property string          $description                               Optional. Description, for groups, supergroups and channel chats. Returned only in getChat.
- * @property string          $invite_link                               Optional. Primary invite link, for groups, supergroups and channel chats. Returned only in getChat.
- * @property Message         $pinned_message                            Optional. The most recent pinned message (by sending date). Returned only in getChat.
- * @property ChatPermissions $permissions                               Optional. Default chat member permissions, for groups and supergroups. Returned only in getChat.
- * @property int             $slow_mode_delay                           Optional. For supergroups, the minimum allowed delay between consecutive messages sent by each unpriviledged user; in seconds. Returned only in getChat.
- * @property int             $unrestrict_boost_count                    Optional. For supergroups, the minimum number of boosts that a non-administrator user needs to add in order to ignore slow mode and chat permissions. Returned only in getChat.
- * @property int             $message_auto_delete_time                  Optional. The time after which all messages sent to the chat will be automatically deleted; in seconds. Returned only in getChat.
- * @property bool            $has_aggressive_anti_spam_enabled          Optional. True, if aggressive anti-spam checks are enabled in the supergroup. The field is only available to chat administrators. Returned only in getChat.
- * @property bool            $has_hidden_members                        Optional. True, if non-administrators can only get the list of bots and administrators in the chat. Returned only in getChat.
- * @property bool            $has_protected_content                     Optional. True, if messages from the chat can't be forwarded to other chats. Returned only in getChat.
- * @property bool            $has_visible_history                       Optional. True, if new chat members will have access to old messages; available only to chat administrators. Returned only in getChat.
- * @property string          $sticker_set_name                          Optional. For supergroups, name of group sticker set. Returned only in getChat.
- * @property bool            $can_set_sticker_set                       Optional. True, if the bot can change the group sticker set. Returned only in getChat.
- * @property string          $custom_emoji_sticker_set_name             Optional. For supergroups, the name of the group's custom emoji sticker set. Custom emoji from this set can be used by all users and bots in the group. Returned only in getChat.
- * @property int             $linked_chat_id                            Optional. Unique identifier for the linked chat, i.e. the discussion group identifier for a channel and vice versa; for supergroups and channel chats. This identifier may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier. Returned only in getChat.
- * @property ChatLocation    $location                                  Optional. For supergroups, the location to which the supergroup is connected. Returned only in getChat.
+ * @property int                  $id                                                     Unique identifier for this chat. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or double-precision float type are safe for storing this identifier.
+ * @property string               $type                                                   Type of chat, can be either “private”, “group”, “supergroup” or “channel”
+ * @property string               $title                                                  Optional. Title, for supergroups, channels and group chats
+ * @property string               $username                                               Optional. Username, for private chats, supergroups and channels if available
+ * @property string               $first_name                                             Optional. First name of the other party in a private chat
+ * @property string               $last_name                                              Optional. Last name of the other party in a private chat
+ * @property bool                 $is_forum                                               Optional. True, if the supergroup chat is a forum (has topics enabled)
+ * @property ChatPhoto            $photo                                                  Optional. Chat photo. Returned only in getChat.
+ * @property string[]             $active_usernames                                       Optional. If non-empty, the list of all active chat usernames; for private chats, supergroups and channels. Returned only in getChat.
+ * @property Birthdate            $birthdate                                              Optional. For private chats, the date of birth of the user. Returned only in getChat.
+ * @property BusinessIntro        $business_intro                                         Optional. For private chats with business accounts, the intro of the business. Returned only in getChat.
+ * @property BusinessLocation     $business_location                                      Optional. For private chats with business accounts, the location of the business. Returned only in getChat.
+ * @property BusinessOpeningHours $business_opening_hours                                 Optional. For private chats with business accounts, the opening hours of the business. Returned only in getChat.
+ * @property Chat                 $personal_chat                                          Optional. For private chats, the personal channel of the user. Returned only in getChat.
+ * @property ReactionType[]       $available_reactions                                    Optional. List of available reactions allowed in the chat. If omitted, then all emoji reactions are allowed. Returned only in getChat.
+ * @property int                  $accent_color_id                                        Optional. Identifier of the accent color for the chat name and backgrounds of the chat photo, reply header, and link preview. See accent colors for more details. Returned only in getChat. Always returned in getChat.
+ * @property string               $background_custom_emoji_id                             Optional. Custom emoji identifier of emoji chosen by the chat for the reply header and link preview background. Returned only in getChat.
+ * @property int                  $profile_accent_color_id                                Optional. Identifier of the accent color for the chat's profile background. See profile accent colors for more details. Returned only in getChat.
+ * @property string               $profile_background_custom_emoji_id                     Optional. Custom emoji identifier of the emoji chosen by the chat for its profile background. Returned only in getChat.
+ * @property string               $emoji_status_custom_emoji_id                           Optional. Custom emoji identifier of the emoji status of the chat or the other party in a private chat. Returned only in getChat.
+ * @property int                  $emoji_status_expiration_date                           Optional. Expiration date of the emoji status of the chat or the other party in a private chat, in Unix time, if any. Returned only in getChat.
+ * @property string               $bio                                                    Optional. Bio of the other party in a private chat. Returned only in getChat.
+ * @property bool                 $has_private_forwards                                   Optional. True, if privacy settings of the other party in the private chat allows to use tg://user?id= links only in chats with the user. Returned only in getChat.
+ * @property bool                 $has_restricted_voice_and_video_messages                Optional. True, if the privacy settings of the other party restrict sending voice and video note messages in the private chat. Returned only in getChat.
+ * @property bool                 $join_to_send_messages                                  Optional. True, if users need to join the supergroup before they can send messages. Returned only in getChat.
+ * @property bool                 $join_by_request                                        Optional. True, if all users directly joining the supergroup need to be approved by supergroup administrators. Returned only in getChat.
+ * @property string               $description                                            Optional. Description, for groups, supergroups and channel chats. Returned only in getChat.
+ * @property string               $invite_link                                            Optional. Primary invite link, for groups, supergroups and channel chats. Returned only in getChat.
+ * @property Message              $pinned_message                                         Optional. The most recent pinned message (by sending date). Returned only in getChat.
+ * @property ChatPermissions      $permissions                                            Optional. Default chat member permissions, for groups and supergroups. Returned only in getChat.
+ * @property int                  $slow_mode_delay                                        Optional. For supergroups, the minimum allowed delay between consecutive messages sent by each unpriviledged user; in seconds. Returned only in getChat.
+ * @property int                  $unrestrict_boost_count                                 Optional. For supergroups, the minimum number of boosts that a non-administrator user needs to add in order to ignore slow mode and chat permissions. Returned only in getChat.
+ * @property int                  $message_auto_delete_time                               Optional. The time after which all messages sent to the chat will be automatically deleted; in seconds. Returned only in getChat.
+ * @property bool                 $has_aggressive_anti_spam_enabled                       Optional. True, if aggressive anti-spam checks are enabled in the supergroup. The field is only available to chat administrators. Returned only in getChat.
+ * @property bool                 $has_hidden_members                                     Optional. True, if non-administrators can only get the list of bots and administrators in the chat. Returned only in getChat.
+ * @property bool                 $has_protected_content                                  Optional. True, if messages from the chat can't be forwarded to other chats. Returned only in getChat.
+ * @property bool                 $has_visible_history                                    Optional. True, if new chat members will have access to old messages; available only to chat administrators. Returned only in getChat.
+ * @property string               $sticker_set_name                                       Optional. For supergroups, name of group sticker set. Returned only in getChat.
+ * @property bool                 $can_set_sticker_set                                    Optional. True, if the bot can change the group sticker set. Returned only in getChat.
+ * @property string               $custom_emoji_sticker_set_name                          Optional. For supergroups, the name of the group's custom emoji sticker set. Custom emoji from this set can be used by all users and bots in the group. Returned only in getChat.
+ * @property int                  $linked_chat_id                                         Optional. Unique identifier for the linked chat, i.e. the discussion group identifier for a channel and vice versa; for supergroups and channel chats. This identifier may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier. Returned only in getChat.
+ * @property ChatLocation         $location                                               Optional. For supergroups, the location to which the supergroup is connected. Returned only in getChat.
  */
 class Chat extends TelegramObject
 {
@@ -57,6 +62,11 @@ class Chat extends TelegramObject
         'is_forum' => 'boolean',
         'photo' => 'ChatPhoto',
         'active_usernames' => 'string[]',
+        'birthdate' => 'Birthdate',
+        'business_intro' => 'BusinessIntro',
+        'business_location' => 'BusinessLocation',
+        'business_opening_hours' => 'BusinessOpeningHours',
+        'personal_chat' => 'Chat',
         'available_reactions' => 'ReactionType[]',
         'accent_color_id' => 'integer',
         'background_custom_emoji_id' => 'string',

--- a/src/Objects/ChatShared.php
+++ b/src/Objects/ChatShared.php
@@ -7,13 +7,19 @@ use WeStacks\TeleBot\Contracts\TelegramObject;
 /**
  * This object contains information about the chat whose identifier was shared with the bot using a KeyboardButtonRequestChat button.
  *
- * @property int $request_id Identifier of the request
- * @property int $chat_id    Identifier of the shared chat. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier. The bot may not have access to the chat and could be unable to use this identifier, unless the chat is already known to the bot by some other means.
+ * @property int         $request_id Identifier of the request
+ * @property int         $chat_id    Identifier of the shared chat. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier. The bot may not have access to the chat and could be unable to use this identifier, unless the chat is already known to the bot by some other means.
+ * @property string      $title      Optional. Title of the chat, if the title was requested by the bot.
+ * @property string      $username   Optional. Username of the chat, if the username was requested by the bot and available.
+ * @property PhotoSize[] $photo      Optional. Available sizes of the chat photo, if the photo was requested by the bot
  */
 class ChatShared extends TelegramObject
 {
     protected $attributes = [
         'request_id' => 'integer',
         'chat_id' => 'integer',
+        'title' => 'string',
+        'username' => 'string',
+        'photo' => 'PhotoSize[]',
     ];
 }

--- a/src/Objects/InputSticker.php
+++ b/src/Objects/InputSticker.php
@@ -8,6 +8,7 @@ use WeStacks\TeleBot\Contracts\TelegramObject;
  * This object describes a sticker to be added to a sticker set.
  *
  * @property InputFile    $sticker       The added sticker. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data. Animated and video stickers can't be uploaded via HTTP URL. [More information on Sending Files »](https://core.telegram.org/bots/api#sending-files)
+ * @property string       $format        Format of the added sticker, must be one of “static” for a .WEBP or .PNG image, “animated” for a .TGS animation, “video” for a WEBM video
  * @property string[]     $emoji_list    List of 1-20 emoji associated with the sticker
  * @property MaskPosition $mask_position Optional. Position where the mask should be placed on faces. For “mask” stickers only.
  * @property string[]     $keywords      Optional. List of 0-20 search keywords for the sticker with total length of up to 64 characters. For “regular” and “custom_emoji” stickers only.
@@ -16,6 +17,7 @@ class InputSticker extends TelegramObject
 {
     protected $attributes = [
         'sticker' => 'InputFile',
+        'format' => 'string',
         'emoji_list' => 'string[]',
         'mask_position' => 'MaskPosition',
         'keywords' => 'string[]',

--- a/src/Objects/KeyboardButtonRequestChat.php
+++ b/src/Objects/KeyboardButtonRequestChat.php
@@ -7,14 +7,17 @@ use WeStacks\TeleBot\Contracts\TelegramObject;
 /**
  * This object defines the criteria used to request a suitable chat. The identifier of the selected chat will be shared with the bot when the corresponding button is pressed.
  *
- * @property int                        $request_id                 Signed 32-bit identifier of the request, which will be received back in the ChatShared object. Must be unique within the message
- * @property bool                       $chat_is_channel            Pass True to request a channel chat, pass False to request a group or a supergroup chat.
- * @property bool                       $chat_is_forum              Optional. Pass True to request a forum supergroup, pass False to request a non-forum chat. If not specified, no additional restrictions are applied.
- * @property bool                       $chat_has_username          Optional. Pass True to request a supergroup or a channel with a username, pass False to request a chat without a username. If not specified, no additional restrictions are applied.
- * @property bool                       $chat_is_created            Optional. Pass True to request a chat owned by the user. Otherwise, no additional restrictions are applied.
- * @property ChatAdministratorRights    $user_administrator_rights  Optional. A JSON-serialized object listing the required administrator rights of the user in the chat. The rights must be a superset of bot_administrator_rights. If not specified, no additional restrictions are applied.
- * @property ChatAdministratorRights    $bot_administrator_rights   Optional. A JSON-serialized object listing the required administrator rights of the bot in the chat. The rights must be a subset of user_administrator_rights. If not specified, no additional restrictions are applied.
- * @property bool                       $bot_is_member              Optional. Pass True to request a chat with the bot as a member. Otherwise, no additional restrictions are applied.
+ * @property int                     $request_id                 Signed 32-bit identifier of the request, which will be received back in the ChatShared object. Must be unique within the message
+ * @property bool                    $chat_is_channel            Pass True to request a channel chat, pass False to request a group or a supergroup chat.
+ * @property bool                    $chat_is_forum              Optional. Pass True to request a forum supergroup, pass False to request a non-forum chat. If not specified, no additional restrictions are applied.
+ * @property bool                    $chat_has_username          Optional. Pass True to request a supergroup or a channel with a username, pass False to request a chat without a username. If not specified, no additional restrictions are applied.
+ * @property bool                    $chat_is_created            Optional. Pass True to request a chat owned by the user. Otherwise, no additional restrictions are applied.
+ * @property ChatAdministratorRights $user_administrator_rights  Optional. A JSON-serialized object listing the required administrator rights of the user in the chat. The rights must be a superset of bot_administrator_rights. If not specified, no additional restrictions are applied.
+ * @property ChatAdministratorRights $bot_administrator_rights   Optional. A JSON-serialized object listing the required administrator rights of the bot in the chat. The rights must be a subset of user_administrator_rights. If not specified, no additional restrictions are applied.
+ * @property bool                    $bot_is_member              Optional. Pass True to request a chat with the bot as a member. Otherwise, no additional restrictions are applied.
+ * @property bool                    $request_name               Optional. Pass True to request the users' first and last name
+ * @property bool                    $request_username           Optional. Pass True to request the users' username
+ * @property bool                    $request_photo              Optional. Pass True to request the users' photo
  */
 class KeyboardButtonRequestChat extends TelegramObject
 {
@@ -27,5 +30,8 @@ class KeyboardButtonRequestChat extends TelegramObject
         'user_administrator_rights' => 'ChatAdministratorRights',
         'bot_administrator_rights' => 'ChatAdministratorRights',
         'bot_is_member' => 'boolean',
+        'request_name' => 'boolean',
+        'request_username' => 'boolean',
+        'request_photo' => 'boolean',
     ];
 }

--- a/src/Objects/KeyboardButtonRequestUsers.php
+++ b/src/Objects/KeyboardButtonRequestUsers.php
@@ -7,10 +7,13 @@ use WeStacks\TeleBot\Contracts\TelegramObject;
 /**
  * This object defines the criteria used to request a suitable user. The identifier of the selected user will be shared with the bot when the corresponding button is pressed.
  *
- * @property int $request_id Signed 32-bit identifier of the request, which will be received back in the UsersShared object. Must be unique within the message
- * @property bool $user_is_bot Optional. Pass True to request a bot, pass False to request a regular user. If not specified, no additional restrictions are applied.
- * @property bool $user_is_premium Optional. Pass True to request a premium user, pass False to request a non-premium user. If not specified, no additional restrictions are applied.
- * @property int $max_quantity Optional. The maximum number of users to be selected; 1-10. Defaults to 1.
+ * @property int  $request_id       Signed 32-bit identifier of the request, which will be received back in the UsersShared object. Must be unique within the message
+ * @property bool $user_is_bot      Optional. Pass True to request a bot, pass False to request a regular user. If not specified, no additional restrictions are applied.
+ * @property bool $user_is_premium  Optional. Pass True to request a premium user, pass False to request a non-premium user. If not specified, no additional restrictions are applied.
+ * @property int  $max_quantity     Optional. The maximum number of users to be selected; 1-10. Defaults to 1.
+ * @property bool $request_name     Optional. Pass True to request the users' first and last name
+ * @property bool $request_username Optional. Pass True to request the users' username
+ * @property bool $request_photo    Optional. Pass True to request the users' photo
  */
 class KeyboardButtonRequestUsers extends TelegramObject
 {
@@ -19,5 +22,8 @@ class KeyboardButtonRequestUsers extends TelegramObject
         'user_is_bot' => 'boolean',
         'user_is_premium' => 'boolean',
         'max_quantity' => 'integer',
+        'request_name' => 'boolean',
+        'request_username' => 'boolean',
+        'request_photo' => 'boolean',
     ];
 }

--- a/src/Objects/Message.php
+++ b/src/Objects/Message.php
@@ -11,7 +11,9 @@ use WeStacks\TeleBot\Contracts\TelegramObject;
  * @property User                          $from                              Optional. Sender of the message; empty for messages sent to channels. For backward compatibility, the field contains a fake sender user in non-channel chats, if the message was sent on behalf of a chat.
  * @property Chat                          $sender_chat                       Optional. Sender of the message, sent on behalf of a chat. For example, the channel itself for channel posts, the supergroup itself for messages from anonymous group administrators, the linked channel for messages automatically forwarded to the discussion group. For backward compatibility, the field from contains a fake sender user in non-channel chats, if the message was sent on behalf of a chat.
  * @property int                           $sender_boost_count                Optional. If the sender of the message boosted the chat, the number of boosts added by the user
+ * @property User                          $sender_business_bot               Optional. The bot that actually sent the message on behalf of the business account. Available only for outgoing messages sent on behalf of the connected business account.
  * @property int                           $date                              Date the message was sent in Unix time
+ * @property string                        $business_connection_id            Optional. Unique identifier of the business connection from which the message was received. If non-empty, the message belongs to a chat of the corresponding business account that is independent from any potential bot chat which might share the same identifier.
  * @property Chat                          $chat                              Conversation the message belongs to
  * @property MessageOrigin                 $forward_origin                    Optional. Information about the original message for forwarded messages
  * @property bool                          $is_automatic_forward              Optional. True, if the message is a channel post that was automatically forwarded to the connected discussion group
@@ -22,6 +24,7 @@ use WeStacks\TeleBot\Contracts\TelegramObject;
  * @property User                          $via_bot                           Optional. Bot through which the message was sent
  * @property int                           $edit_date                         Optional. Date the message was last edited in Unix time
  * @property bool                          $has_protected_content             Optional. True, if the message can't be forwarded
+ * @property bool                          $is_from_offline                   Optional. True, if the message was sent by an implicit action, for example, as an away or a greeting business message, or as a scheduled message
  * @property string                        $media_group_id                    Optional. The unique identifier of a media message group this message belongs to
  * @property string                        $author_signature                  Optional. Signature of the post author for messages in channels, or the custom title of an anonymous group administrator
  * @property string                        $text                              Optional. For text messages, the actual UTF-8 text of the message, 0-4096 characters
@@ -90,7 +93,9 @@ class Message extends TelegramObject
         'from' => 'User',
         'sender_chat' => 'Chat',
         'sender_boost_count' => 'integer',
+        'sender_business_bot' => 'User',
         'date' => 'integer',
+        'business_connection_id' => 'string',
         'chat' => 'Chat',
         'forward_origin' => 'MessageOrigin',
         'is_topic_message' => 'boolean',
@@ -102,6 +107,7 @@ class Message extends TelegramObject
         'via_bot' => 'User',
         'edit_date' => 'integer',
         'has_protected_content' => 'boolean',
+        'is_from_offline' => 'boolean',
         'media_group_id' => 'string',
         'author_signature' => 'string',
         'text' => 'string',

--- a/src/Objects/SharedUser.php
+++ b/src/Objects/SharedUser.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace WeStacks\TeleBot\Objects;
+
+use WeStacks\TeleBot\Contracts\TelegramObject;
+
+/**
+ * This object contains information about a user that was shared with the bot using a [KeyboardButtonRequestUser](https://core.telegram.org/bots/api#keyboardbuttonrequestuser) button.
+ *
+ * @property int         $user_id    Identifier of the shared user. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so 64-bit integers or double-precision float types are safe for storing these identifiers. The bot may not have access to the user and could be unable to use this identifier, unless the user is already known to the bot by some other means.
+ * @property string      $first_name Optional. First name of the user, if the name was requested by the bot
+ * @property string      $last_name  Optional. Last name of the user, if the name was requested by the bot
+ * @property string      $username   Optional. Username of the user, if the username was requested by the bot
+ * @property PhotoSize[] $photo      Optional. Available sizes of the chat photo, if the photo was requested by the bot
+ */
+class SharedUser extends TelegramObject
+{
+    protected $attributes = [
+        'user_id' => 'integer',
+        'first_name' => 'string',
+        'last_name' => 'string',
+        'username' => 'string',
+        'photo' => 'PhotoSize[]',
+    ];
+}

--- a/src/Objects/StickerSet.php
+++ b/src/Objects/StickerSet.php
@@ -10,8 +10,6 @@ use WeStacks\TeleBot\Contracts\TelegramObject;
  * @property string    $name           Sticker set name
  * @property string    $title          Sticker set title
  * @property string    $sticker_type   Type of stickers in the set, currently one of “regular”, “mask”, “custom_emoji”
- * @property bool      $is_animated    True, if the sticker set contains animated stickers
- * @property bool      $is_video       True, if the sticker set contains [video stickers](https://telegram.org/blog/video-stickers-better-reactions)
  * @property Sticker[] $stickers       List of all set stickers
  * @property PhotoSize $thumbnail      Optional. Sticker set thumbnail in the .WEBP, .TGS, or .WEBM format
  */
@@ -21,8 +19,6 @@ class StickerSet extends TelegramObject
         'name' => 'string',
         'title' => 'string',
         'sticker_type' => 'string',
-        'is_animated' => 'boolean',
-        'is_video' => 'boolean',
         'contains_masks' => 'boolean', // DEPRECATED
         'stickers' => 'Sticker[]',
         'thumbnail' => 'PhotoSize',

--- a/src/Objects/Update.php
+++ b/src/Objects/Update.php
@@ -8,25 +8,29 @@ use WeStacks\TeleBot\Contracts\TelegramObject;
  * This [object](https://core.telegram.org/bots/api#available-types) represents an incoming update.
  * At most one of the optional parameters can be present in any given update.
  *
- * @property int                            $update_id              The update's unique identifier. Update identifiers start from a certain positive number and increase sequentially. This ID becomes especially handy if you're using Webhooks, since it allows you to ignore repeated updates or to restore the correct update sequence, should they get out of order. If there are no new updates for at least a week, then identifier of the next update will be chosen randomly instead of sequentially.
- * @property Message                        $message                Optional. New incoming message of any kind — text, photo, sticker, etc.
- * @property Message                        $edited_message         Optional. New version of a message that is known to the bot and was edited
- * @property Message                        $channel_post           Optional. New incoming channel post of any kind — text, photo, sticker, etc.
- * @property Message                        $edited_channel_post    Optional. New version of a channel post that is known to the bot and was edited
- * @property MessageReactionUpdated         $message_reaction       Optional. A reaction to a message was changed by a user. The bot must be an administrator in the chat and must explicitly specify "message_reaction" in the list of allowed_updates to receive these updates. The update isn't received for reactions set by bots.
- * @property MessageReactionCountUpdated    $message_reaction_count Optional. Reactions to a message with anonymous reactions were changed. The bot must be an administrator in the chat and must explicitly specify "message_reaction_count" in the list of allowed_updates to receive these updates. The updates are grouped and can be sent with delay up to a few minutes.
- * @property InlineQuery                    $inline_query           Optional. New incoming inline query
- * @property ChosenInlineResult             $chosen_inline_result   Optional. The result of an inline query that was chosen by a user and sent to their chat partner. Please see our documentation on the feedback collecting for details on how to enable these updates for your bot.
- * @property CallbackQuery                  $callback_query         Optional. New incoming callback query
- * @property ShippingQuery                  $shipping_query         Optional. New incoming shipping query. Only for invoices with flexible price
- * @property PreCheckoutQuery               $pre_checkout_query     Optional. New incoming pre-checkout query. Contains full information about checkout
- * @property Poll                           $poll                   Optional. New poll state. Bots receive only updates about stopped polls and polls, which are sent by the bot
- * @property PollAnswer                     $poll_answer            Optional. A user changed their answer in a non-anonymous poll. Bots receive new votes only in polls that were sent by the bot itself.
- * @property ChatMemberUpdated              $my_chat_member         Optional. The bot's chat member status was updated in a chat. For private chats, this update is received only when the bot is blocked or unblocked by the user.
- * @property ChatMemberUpdated              $chat_member            Optional. A chat member's status was updated in a chat. The bot must be an administrator in the chat and must explicitly specify “chat_member” in the list of allowed_updates to receive these updates.
- * @property ChatJoinRequest                $chat_join_request      Optional. A request to join the chat has been sent. The bot must have the can_invite_users administrator right in the chat to receive these updates.
- * @property ChatBoostUpdated               $chat_boost             Optional. A chat boost was added or changed. The bot must be an administrator in the chat to receive these updates.
- * @property ChatBoostRemoved               $removed_chat_boost     Optional. A boost was removed from a chat. The bot must be an administrator in the chat to receive these updates.
+ * @property int                         $update_id                       The update's unique identifier. Update identifiers start from a certain positive number and increase sequentially. This ID becomes especially handy if you're using Webhooks, since it allows you to ignore repeated updates or to restore the correct update sequence, should they get out of order. If there are no new updates for at least a week, then identifier of the next update will be chosen randomly instead of sequentially.
+ * @property Message                     $message                         Optional. New incoming message of any kind — text, photo, sticker, etc.
+ * @property Message                     $edited_message                  Optional. New version of a message that is known to the bot and was edited
+ * @property Message                     $channel_post                    Optional. New incoming channel post of any kind — text, photo, sticker, etc.
+ * @property Message                     $edited_channel_post             Optional. New version of a channel post that is known to the bot and was edited
+ * @property BusinessConnection          $business_connection             Optional. The bot was connected to or disconnected from a business account, or a user edited an existing connection with the bot
+ * @property Message                     $business_message                Optional. New non-service message from a connected business account
+ * @property Message                     $edited_business_message         Optional. New version of a message from a connected business account
+ * @property BusinessMessagesDeleted     $deleted_business_messages       Optional. Messages were deleted from a connected business account
+ * @property MessageReactionUpdated      $message_reaction                Optional. A reaction to a message was changed by a user. The bot must be an administrator in the chat and must explicitly specify "message_reaction" in the list of allowed_updates to receive these updates. The update isn't received for reactions set by bots.
+ * @property MessageReactionCountUpdated $message_reaction_count          Optional. Reactions to a message with anonymous reactions were changed. The bot must be an administrator in the chat and must explicitly specify "message_reaction_count" in the list of allowed_updates to receive these updates. The updates are grouped and can be sent with delay up to a few minutes.
+ * @property InlineQuery                 $inline_query                    Optional. New incoming inline query
+ * @property ChosenInlineResult          $chosen_inline_result            Optional. The result of an inline query that was chosen by a user and sent to their chat partner. Please see our documentation on the feedback collecting for details on how to enable these updates for your bot.
+ * @property CallbackQuery               $callback_query                  Optional. New incoming callback query
+ * @property ShippingQuery               $shipping_query                  Optional. New incoming shipping query. Only for invoices with flexible price
+ * @property PreCheckoutQuery            $pre_checkout_query              Optional. New incoming pre-checkout query. Contains full information about checkout
+ * @property Poll                        $poll                            Optional. New poll state. Bots receive only updates about stopped polls and polls, which are sent by the bot
+ * @property PollAnswer                  $poll_answer                     Optional. A user changed their answer in a non-anonymous poll. Bots receive new votes only in polls that were sent by the bot itself.
+ * @property ChatMemberUpdated           $my_chat_member                  Optional. The bot's chat member status was updated in a chat. For private chats, this update is received only when the bot is blocked or unblocked by the user.
+ * @property ChatMemberUpdated           $chat_member                     Optional. A chat member's status was updated in a chat. The bot must be an administrator in the chat and must explicitly specify “chat_member” in the list of allowed_updates to receive these updates.
+ * @property ChatJoinRequest             $chat_join_request               Optional. A request to join the chat has been sent. The bot must have the can_invite_users administrator right in the chat to receive these updates.
+ * @property ChatBoostUpdated            $chat_boost                      Optional. A chat boost was added or changed. The bot must be an administrator in the chat to receive these updates.
+ * @property ChatBoostRemoved            $removed_chat_boost              Optional. A boost was removed from a chat. The bot must be an administrator in the chat to receive these updates.
  */
 class Update extends TelegramObject
 {
@@ -36,6 +40,10 @@ class Update extends TelegramObject
         'edited_message' => 'Message',
         'channel_post' => 'Message',
         'edited_channel_post' => 'Message',
+        'business_connection' => 'BusinessConnection',
+        'business_message' => 'Message',
+        'edited_business_message' => 'Message',
+        'deleted_business_messages' => 'BusinessMessagesDeleted',
         'message_reaction' => 'MessageReactionUpdated',
         'message_reaction_count' => 'MessageReactionCountUpdated',
         'inline_query' => 'InlineQuery',
@@ -86,6 +94,8 @@ class Update extends TelegramObject
                 $this->channel_post ??
                 $this->edited_channel_post ??
                 $this->callback_query->message ??
+                $this->business_message ??
+                $this->edited_business_message ??
                 null;
     }
 
@@ -128,6 +138,8 @@ class Update extends TelegramObject
                 $this->my_chat_member->from ??
                 $this->chat_join_request->from ??
                 $this->message_reaction->user ??
+                $this->business_message->from ??
+                $this->edited_business_message->from ??
                 null;
     }
 }

--- a/src/Objects/User.php
+++ b/src/Objects/User.php
@@ -18,6 +18,7 @@ use WeStacks\TeleBot\Contracts\TelegramObject;
  * @property bool   $can_join_groups             Optional. True, if the bot can be invited to groups. Returned only in getMe.
  * @property bool   $can_read_all_group_messages Optional. True, if privacy mode is disabled for the bot. Returned only in getMe.
  * @property bool   $supports_inline_queries     Optional. True, if the bot supports inline queries. Returned only in getMe.
+ * @property bool   $can_connect_to_business     Optional. True, if the bot can be connected to a Telegram Business account to receive its messages. Returned only in getMe.
  */
 class User extends TelegramObject
 {
@@ -33,5 +34,6 @@ class User extends TelegramObject
         'can_join_groups' => 'boolean',
         'can_read_all_group_messages' => 'boolean',
         'supports_inline_queries' => 'boolean',
+        'can_connect_to_business' => 'boolean',
     ];
 }

--- a/src/Objects/UsersShared.php
+++ b/src/Objects/UsersShared.php
@@ -5,15 +5,15 @@ namespace WeStacks\TeleBot\Objects;
 use WeStacks\TeleBot\Contracts\TelegramObject;
 
 /**
- * This object contains information about the users whose identifiers were shared with the bot using a KeyboardButtonRequestUsers button.
+ * This object contains information about the users whose identifiers were shared with the bot using a [KeyboardButtonRequestUsers](https://core.telegram.org/bots/api#keyboardbuttonrequestusers) button.
  *
- * @property int $request_id Identifier of the request
- * @property int $user_id    Identifiers of the shared users. These numbers may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting them. But they have at most 52 significant bits, so 64-bit integers or double-precision float types are safe for storing these identifiers. The bot may not have access to the users and could be unable to use these identifiers, unless the users are already known to the bot by some other means.
+ * @property int          $request_id Identifier of the request
+ * @property SharedUser[] $users      Information about users shared with the bot.
  */
 class UsersShared extends TelegramObject
 {
     protected $attributes = [
         'request_id' => 'integer',
-        'user_ids' => 'integer[]',
+        'users' => 'SharedUser[]',
     ];
 }


### PR DESCRIPTION
I made revisions to existing methods and objects, as well as added new ones from update 7.2. However, I only tested them with mocks as I didn't have the opportunity to test them on the real API.

I also have a question regarding the chat() and user() methods in the `WeStacks\TeleBot\Objects\Update` object in relation to the new attributes (Business Connection). Please, feel free to correct me if necessary.

[March 31, 2024 - Bot API 7.2](https://core.telegram.org/bots/api#march-31-2024)

Integration with Business Accounts

- [x] Added the class BusinessConnection and updates about the connection or disconnection of the bot to a business account, represented by the field business_connection in the class Update.
- [x] Added updates about new messages in a business account connected to the bot, represented by the field business_message in the class Update.
- [x] Added updates about message edits in a business account connected to the bot, represented by the field edited_business_message in the class Update.
- [x] Added updates about message deletion in a business account connected to the bot, represented by the class BusinessMessagesDeleted and the field deleted_business_messages in the class Update.
- [x] Added the method getBusinessConnection.

Working on Behalf of Business Accounts

- [x] Added the parameter business_connection_id to the methods sendMessage, sendPhoto, sendVideo, sendAnimation, sendAudio, sendDocument, sendSticker, sendVideoNote, sendVoice, sendLocation, sendVenue, sendContact, sendPoll, sendDice, sendGame, and sendMediaGroup.
- [x] Added the parameter business_connection_id to the method sendChatAction.
- [x] Added the field business_connection_id to the class Message.
- [x] Added the field sender_business_bot to the class Message.

Information about Business Accounts

- [x] Added the class BusinessIntro and the field business_intro to the class Chat.
- [x] Added the class BusinessLocation and the field business_location to the class Chat.
- [x] Added the classes BusinessOpeningHours and BusinessOpeningHoursInterval and the field business_opening_hours to the class Chat.

Mixed-Format Sticker Packs

- [x] Removed the fields is_animated and is_video from the class StickerSet.
- [x] Added the field format to the class InputSticker.
- [x] Removed the parameter sticker_format from the method createNewStickerSet.
- [x] Added the parameter format to the method setStickerSetThumbnail.
- [x] Increased the maximum number of stickers in any regular and mask sticker set to 120.
- [x] Allowed to upload WEBM stickers using SendSticker.

Request Chat Improvements

- [x] Added the fields request_name, request_username, and request_photo to the class KeyboardButtonRequestUsers.
- [x] Added the fields request_title, request_username, and request_photo to the class KeyboardButtonRequestChat.
- [x] Added the class SharedUser and replaced the field user_ids in the class UsersShared with the field users.
- [x] Added the fields title, username, and photo to the class ChatShared.

Other Changes

- [x] Added the field is_from_offline to the class Message.
- [x] Added the field can_connect_to_business to the class User.
- [x] Added the field personal_chat to the class Chat.
- [x] Added the method replaceStickerInSet.
- [x] Added the class Birthdate and the field birthdate to the class Chat.
- [ ] Added the field BiometricManager to the class WebApp.
